### PR TITLE
🔧 fix(ci): upgrade actions and improve fitbit token recovery

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
 
     - name: Get most recent successful run
       id: get-successful-run
-      uses: actions/github-script@v7  
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -71,7 +71,7 @@ jobs:
           }
 
     - name: Download Fitbit Tokens from GitHub Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: fitbit-tokens
         run-id: ${{ steps.get-successful-run.outputs.runId }}
@@ -80,7 +80,7 @@ jobs:
       continue-on-error: true
 
     - name: Download Strava Tokens from GitHub Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: strava-tokens
         run-id: ${{ steps.get-successful-run.outputs.runId }}
@@ -166,22 +166,35 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Check for token refresh failures
-      if: steps.fitbit_tokens.outcome == 'failure'
+    - name: Report Fitbit token refresh failure
+      if: always() && steps.fitbit_tokens.outcome == 'failure'
       run: |
-        echo "❌ Fitbit token refresh failed"
-        echo "Please re-authenticate Fitbit tokens:"
-        echo "Run: python -m app.fitbit fitbit-auth"
-        exit 1
+        echo "::warning::Fitbit token refresh failed. Re-authenticate and update GitHub secrets/vars."
+        {
+          echo "## Fitbit token refresh required"
+          echo ""
+          echo "The workflow continued, but Fitbit token refresh failed."
+          echo "Run locally:"
+          echo "\`./scripts/refresh-fitbit-secrets.sh --dispatch\`"
+          echo ""
+          echo "Manual fallback:"
+          echo "1. \`uv run python -m app.fitbit fitbit-auth\`"
+          echo "2. Update \`FITBIT_ACCESS_TOKEN\`, \`FITBIT_REFRESH_TOKEN\` (secrets) and \`FITBIT_EXPIRES_AT\` (variable)"
+          echo "3. Trigger \`main.yaml\` with \`skip_artifact=true\`"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload Fitbit Tokens to GitHub Artifacts
-      uses: actions/upload-artifact@v4
+      if: always()
+      uses: actions/upload-artifact@v7
       with:
         name: fitbit-tokens
         path: fitbit_tokens.json
+        if-no-files-found: warn
 
     - name: Upload Strava Tokens to GitHub Artifacts
-      uses: actions/upload-artifact@v4
+      if: always()
+      uses: actions/upload-artifact@v7
       with:
         name: strava-tokens
         path: strava_tokens.json
+        if-no-files-found: warn

--- a/app/README.md
+++ b/app/README.md
@@ -91,17 +91,23 @@ docker run --env-file .env -v $(pwd):/app fitness-cli python -m app.fitbit fitbi
 When tokens expire and need manual re-authentication:
 
 ```bash
-# Re-authenticate and push tokens to GitHub Secrets
-uv run python -m app.fitbit fitbit-auth && \
-  gh secret set FITBIT_ACCESS_TOKEN --body "$(grep '^FITBIT_ACCESS_TOKEN=' .env | cut -d= -f2)" && \
-  gh secret set FITBIT_REFRESH_TOKEN --body "$(grep '^FITBIT_REFRESH_TOKEN=' .env | cut -d= -f2)" && \
-  gh variable set FITBIT_EXPIRES_AT --body "$(grep '^FITBIT_EXPIRES_AT=' .env | cut -d= -f2)"
+# One-command recovery: OAuth re-auth + secret/variable update + workflow dispatch
+./scripts/refresh-fitbit-secrets.sh --dispatch
+```
 
-# Trigger workflow with skip_artifact to use GitHub Secrets instead of stale artifacts
+Manual fallback:
+
+```bash
+uv run python -m app.fitbit fitbit-auth
+gh secret set FITBIT_ACCESS_TOKEN --body "$(grep '^FITBIT_ACCESS_TOKEN=' .env | cut -d= -f2)"
+gh secret set FITBIT_REFRESH_TOKEN --body "$(grep '^FITBIT_REFRESH_TOKEN=' .env | cut -d= -f2)"
+gh variable set FITBIT_EXPIRES_AT --body "$(grep '^FITBIT_EXPIRES_AT=' .env | cut -d= -f2)"
 gh workflow run main.yaml -f skip_artifact=true
 ```
 
-**Note:** The `skip_artifact=true` flag tells the workflow to use GitHub Secrets directly instead of downloading tokens from the previous run's artifacts. Use this when you've manually refreshed tokens.
+**Notes:**
+- `skip_artifact=true` tells the workflow to use GitHub Secrets/variables instead of tokens from a previous artifact.
+- Fitbit re-authentication is human-in-the-loop (browser OAuth consent required).
 
 ## Notes
 

--- a/scripts/refresh-fitbit-secrets.sh
+++ b/scripts/refresh-fitbit-secrets.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-.env}"
+DISPATCH="false"
+
+if [[ "${1:-}" == "--dispatch" ]]; then
+  DISPATCH="true"
+fi
+
+for cmd in uv gh grep cut; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Environment file not found: $ENV_FILE" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+echo "Starting Fitbit OAuth re-authentication..."
+uv run python -m app.fitbit fitbit-auth
+
+get_env_value() {
+  local key="$1"
+  local value
+  value=$(grep "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- || true)
+
+  if [[ -z "$value" ]]; then
+    echo "Missing ${key} in ${ENV_FILE}" >&2
+    exit 1
+  fi
+
+  printf '%s' "$value"
+}
+
+FITBIT_ACCESS_TOKEN=$(get_env_value "FITBIT_ACCESS_TOKEN")
+FITBIT_REFRESH_TOKEN=$(get_env_value "FITBIT_REFRESH_TOKEN")
+FITBIT_EXPIRES_AT=$(get_env_value "FITBIT_EXPIRES_AT")
+
+echo "Updating GitHub Actions secrets/variables..."
+gh secret set FITBIT_ACCESS_TOKEN --body "$FITBIT_ACCESS_TOKEN"
+gh secret set FITBIT_REFRESH_TOKEN --body "$FITBIT_REFRESH_TOKEN"
+gh variable set FITBIT_EXPIRES_AT --body "$FITBIT_EXPIRES_AT"
+
+echo "Fitbit secrets and variable updated."
+
+if [[ "$DISPATCH" == "true" ]]; then
+  echo "Dispatching workflow with skip_artifact=true..."
+  gh workflow run main.yaml -f skip_artifact=true
+  echo "Workflow dispatched."
+else
+  echo "Next step: gh workflow run main.yaml -f skip_artifact=true"
+fi


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions used in `main.yaml` to Node 24 runtimes (`checkout@v6`, `github-script@v9`, `download-artifact@v8`, `upload-artifact@v7`)
- replace hard failure on Fitbit token refresh with warning + job summary guidance to keep runs actionable
- always attempt token artifact uploads with `if-no-files-found: warn`
- add `scripts/refresh-fitbit-secrets.sh` for one-command Fitbit re-auth, secret/variable update, and optional workflow dispatch
- document the helper flow and human-in-the-loop OAuth requirement in `app/README.md`

## Validation
- `bash -n scripts/refresh-fitbit-secrets.sh`
- `pre-commit run -a`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main.yaml')"`

🤖 Generated with Codex
