### PR TITLE
🔧 fix(ci): restore hard fail on fitbit token refresh

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -166,7 +166,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Report Fitbit token refresh failure
+    - name: Fail on Fitbit token refresh failure
       if: always() && steps.fitbit_tokens.outcome == 'failure'
       run: |
         echo "::warning::Fitbit token refresh failed. Re-authenticate and update GitHub secrets/vars."
@@ -182,6 +182,7 @@ jobs:
           echo "2. Update \`FITBIT_ACCESS_TOKEN\`, \`FITBIT_REFRESH_TOKEN\` (secrets) and \`FITBIT_EXPIRES_AT\` (variable)"
           echo "3. Trigger \`main.yaml\` with \`skip_artifact=true\`"
         } >> "$GITHUB_STEP_SUMMARY"
+        exit 1
 
     - name: Upload Fitbit Tokens to GitHub Artifacts
       if: always()

--- a/app/README.md
+++ b/app/README.md
@@ -108,6 +108,7 @@ gh workflow run main.yaml -f skip_artifact=true
 **Notes:**
 - `skip_artifact=true` tells the workflow to use GitHub Secrets/variables instead of tokens from a previous artifact.
 - Fitbit re-authentication is human-in-the-loop (browser OAuth consent required).
+- `./scripts/refresh-fitbit-secrets.sh` is a Bash wrapper but still requires `uv` (it runs `uv run python -m app.fitbit fitbit-auth`).
 
 ## Notes
 

--- a/docs/kaizen.md
+++ b/docs/kaizen.md
@@ -1,0 +1,1 @@
+2026-04-13T08:54:56Z | ci/workflow | correction | restored hard-fail on fitbit token refresh step while keeping explicit recovery summary + helper script → monitor scheduled run failures and refresh tokens via script when red


### PR DESCRIPTION
## Summary
- restore hard-fail behavior when Fitbit token refresh fails (`exit 1`) so the workflow is explicitly red for human intervention
- keep workflow guidance in step summary pointing to `./scripts/refresh-fitbit-secrets.sh --dispatch`
- clarify in docs that the helper script still requires `uv` under the hood
- append kaizen correction entry per repo policy

## Validation
- `pre-commit run -a`

🤖 Generated with Codex
